### PR TITLE
Add keybinding system.

### DIFF
--- a/OctoGhast.UserInterface/Core/Component.cs
+++ b/OctoGhast.UserInterface/Core/Component.cs
@@ -65,6 +65,8 @@ namespace OctoGhast.UserInterface.Core
 
         public event EventHandler Quitting;
 
+        public event EventHandler<int> KeyBindingAction;
+
         public event EventHandler<KeyboardEventArgs> KeyPressed;
 
         public event EventHandler<KeyboardEventArgs> KeyReleased;
@@ -151,6 +153,10 @@ namespace OctoGhast.UserInterface.Core
 
         public virtual void OnQuitting() {
             if (Quitting != null) Quitting(this, EventArgs.Empty);
+        }
+
+        public virtual void OnKeyBindingAction(int actionId) {
+            if (KeyBindingAction != null) KeyBindingAction(this, actionId);
         }
 
         public virtual void OnKeyPressed(KeyboardData keyData) {

--- a/OctoGhast.UserInterface/Core/Messages/KeyBindInfo.cs
+++ b/OctoGhast.UserInterface/Core/Messages/KeyBindInfo.cs
@@ -1,0 +1,49 @@
+﻿using System.Data;
+using libtcod;
+
+namespace OctoGhast.UserInterface.Core.Messages
+{
+    /// <summary>
+    /// Provide a wrapper around a key binding
+    /// </summary>
+    public class KeyBindInfo
+    {
+        public char Key { get; private set; }
+        public TCODKeyCode KeyCode { get; private set; }
+
+        public KeyBindInfo(char key) {
+            Key = key;
+        }
+
+        public KeyBindInfo(TCODKeyCode keyCode) {
+            KeyCode = keyCode;
+        }
+
+        public override bool Equals(object obj) {
+            if (!(obj is KeyBindInfo)) return false;
+
+            return ((KeyBindInfo) obj).Key == Key && ((KeyBindInfo) obj).KeyCode == KeyCode;
+        }
+
+        public override int GetHashCode() {
+            return Key.GetHashCode() ^ KeyCode.GetHashCode();
+        }
+
+        // Aids for implicit conversions.
+        // Into the danger zoooone
+        public static implicit operator KeyBindInfo(TCODKeyCode code) {
+            return new KeyBindInfo(code);
+        }
+
+        public static implicit operator KeyBindInfo(char code) {
+            return new KeyBindInfo(code);
+        }
+
+        public static implicit operator KeyBindInfo(KeyboardData data) {
+            return new KeyBindInfo(data.KeyCode)
+            {
+                Key = data.Character
+            };
+        }
+    }
+}

--- a/OctoGhast.UserInterface/Core/ScreenBase.cs
+++ b/OctoGhast.UserInterface/Core/ScreenBase.cs
@@ -1,13 +1,47 @@
-﻿namespace OctoGhast.UserInterface.Core
+﻿using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using OctoGhast.UserInterface.Core.Messages;
+
+namespace OctoGhast.UserInterface.Core
 {
     public abstract class ScreenBase : Manager
     {
+        private ConcurrentDictionary<int, Action> actionMap { get; set; }
+
+        protected ScreenBase() {
+            actionMap = new ConcurrentDictionary<int, Action>();
+        }
+
         /// <summary>
         /// Navigate to <param name="screen"></param> on the next UI tick.
         /// </summary>
         /// <param name="screen">Screen to navigate to</param>
         public void NavigateTo(ScreenBase screen) {
             ParentWindow.EnqueueScreen(screen);
+        }
+
+        public override void OnKeyBindingAction(int action) {
+            base.OnKeyBindingAction(action);
+
+            Action callback;
+            if (actionMap.TryGetValue(action, out callback)) {
+                callback();
+            }
+        }
+
+        /// <summary>
+        /// Register an ActionId to a callback.
+        /// </summary>
+        /// <param name="actionId"></param>
+        /// <param name="action"></param>
+        public void RegisterAction(int actionId, Action action) {
+            actionMap.AddOrUpdate(actionId, v => action, (i, action1) => action);
+        }
+
+        public void UnregisterAction(int actionId) {
+            Action unused;
+            actionMap.TryRemove(actionId, out unused);
         }
     }
 }

--- a/OctoGhast.UserInterface/OctoGhast.UserInterface.csproj
+++ b/OctoGhast.UserInterface/OctoGhast.UserInterface.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Controls\Panel.cs" />
     <Compile Include="Controls\TextEntry.cs" />
     <Compile Include="Controls\Tooltip.cs" />
+    <Compile Include="Core\Messages\KeyBindInfo.cs" />
     <Compile Include="Core\ScreenBase.cs" />
     <Compile Include="Core\Window.cs" />
     <Compile Include="Core\Canvas.cs" />

--- a/OctoGhast/GameActions.cs
+++ b/OctoGhast/GameActions.cs
@@ -1,0 +1,16 @@
+﻿// ReSharper disable InconsistentNaming
+namespace OctoGhast
+{
+    /// <summary>
+    /// Global constants for actionId'
+    /// </summary>
+    public enum GameActions
+    {
+        GameMap_MoveNorth,
+        GameMap_MoveSouth,
+        GameMap_MoveLeft,
+        GameMap_MoveRight,
+        GameMap_ShowLighting
+    }
+}
+// ReSharper restore InconsistentNaming

--- a/OctoGhast/OctoGhast.csproj
+++ b/OctoGhast/OctoGhast.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Framework\Game.cs" />
     <Compile Include="Framework\IGame.cs" />
     <Compile Include="Framework\InputManager.cs" />
+    <Compile Include="GameActions.cs" />
     <Compile Include="Map\GameMap.cs" />
     <Compile Include="Map\Tile.cs" />
     <Compile Include="OctoGhastGame.cs" />

--- a/OctoGhast/OctoGhastGame.cs
+++ b/OctoGhast/OctoGhastGame.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using libtcod;
 using OctoGhast.Framework;
 using OctoGhast.Renderer.Screens;
 using OctoGhast.UserInterface.Core;
+using OctoGhast.UserInterface.Core.Messages;
 
 namespace OctoGhast
 {
@@ -28,6 +30,13 @@ namespace OctoGhast
             Screens = new Stack<ScreenBase>();
 
             EnqueueScreen(new TitleScreen());
+
+            // Register our keybindings -> actions
+            RegisterKey(TCODKeyCode.Up, (int) GameActions.GameMap_MoveNorth);
+            RegisterKey(TCODKeyCode.Down, (int) GameActions.GameMap_MoveSouth);
+            RegisterKey(TCODKeyCode.Left, (int) GameActions.GameMap_MoveLeft);
+            RegisterKey(TCODKeyCode.Right, (int) GameActions.GameMap_MoveRight);
+            RegisterKey(TCODKeyCode.F1, (int) GameActions.GameMap_ShowLighting);
         }
     }
 }

--- a/OctoGhast/Renderer/Screens/Game/MainGame.cs
+++ b/OctoGhast/Renderer/Screens/Game/MainGame.cs
@@ -11,28 +11,19 @@ using OctoGhast.Spatial;
 using OctoGhast.UserInterface.Controls;
 using OctoGhast.UserInterface.Core;
 using OctoGhast.UserInterface.Core.Messages;
-using OctoGhast.UserInterface.Templates;
 
 namespace OctoGhast.Renderer.Screens
 {
     public class MainGame : ScreenBase
     {
         private IMapViewModel MapModel { get; set; }
-        private Dictionary<TCODKeyCode, Action> KeyBindingMap { get; set; }
 
         public MainGame() {
-            KeyBindingMap = new Dictionary<TCODKeyCode, Action>();
-            RegisterKeys();
-        }
-
-        private void RegisterKeys() {
-            Action<TCODKeyCode, Action> register = (key, action) => KeyBindingMap.Add(key, action);
-
-            register(TCODKeyCode.Up, () => MapModel.Player.MoveTo(MapModel.Player.Position.Offset(0, -1)));
-            register(TCODKeyCode.Down, () => MapModel.Player.MoveTo(MapModel.Player.Position.Offset(0, +1)));
-            register(TCODKeyCode.Left, () => MapModel.Player.MoveTo(MapModel.Player.Position.Offset(-1, 0)));
-            register(TCODKeyCode.Right, () => MapModel.Player.MoveTo(MapModel.Player.Position.Offset(+1, 0)));
-            register(TCODKeyCode.F1, () => MapModel.DrawLighting = !MapModel.DrawLighting);
+            RegisterAction((int)GameActions.GameMap_MoveNorth, () => MapModel.Player.MoveTo(MapModel.Player.Position.Offset(0, -1)));
+            RegisterAction((int)GameActions.GameMap_MoveSouth, () => MapModel.Player.MoveTo(MapModel.Player.Position.Offset(0, +1)));
+            RegisterAction((int)GameActions.GameMap_MoveLeft, () => MapModel.Player.MoveTo(MapModel.Player.Position.Offset(-1, 0)));
+            RegisterAction((int)GameActions.GameMap_MoveRight, () => MapModel.Player.MoveTo(MapModel.Player.Position.Offset(+1, 0)));
+            RegisterAction((int) GameActions.GameMap_ShowLighting, () => MapModel.DrawLighting = !MapModel.DrawLighting);
         }
 
         public override void OnSettingUp() {
@@ -81,15 +72,6 @@ namespace OctoGhast.Renderer.Screens
             {
                 mapControl
             });
-        }
-
-        public override void OnKeyPressed(KeyboardData keyData) {
-            base.OnKeyPressed(keyData);
-
-            Action keyBinding = null;
-            if (KeyBindingMap.TryGetValue(keyData.KeyCode, out keyBinding)) {
-                keyBinding();
-            }
         }
     }
 }


### PR DESCRIPTION
Resolves Issue #2 

Keybindings are registered on startup and broadcast to the currently
active screen on having the bound key pressed.

Keybindings can be changed at runtime. The `actionId` is
broadcast to every `Manager` currently running in the `Window`.
